### PR TITLE
chore: add prebuilds for Node 16

### DIFF
--- a/.github/workflows/prebuild-alpine.yml
+++ b/.github/workflows/prebuild-alpine.yml
@@ -45,4 +45,4 @@ jobs:
         run: cat package.json
       - name: Build release
         run: |
-          detect-libc node ./node_modules/prebuild/bin.js -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 15.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}
+          detect-libc node ./node_modules/prebuild/bin.js -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -43,4 +43,4 @@ jobs:
         run: cat package.json
       - name: Build release
         run: |
-          node ./node_modules/prebuild/bin.js -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 15.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}
+          node ./node_modules/prebuild/bin.js -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We are creating images with node 16, and they won't build now. We are missing the node 16 prebuilds, and `node-gyp` is not supported by default on the underlying node images.

I have noticed that in the electron prebuilds, we do not support node 13+, so I added node 16 only to the other two actions.